### PR TITLE
testing out if defered scripts improve page load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,17 @@
 <head>
   <meta charset="utf-8">
   <title>Proxy</title>
+
+  <script src="http://34.233.106.94/1/bundle.js" defer></script>
+
+  <script src="http://ec2-18-223-214-235.us-east-2.compute.amazonaws.com/1/bundle.js" defer></script>
+
+  <script src="http://ec2-18-223-135-118.us-east-2.compute.amazonaws.com/bundle.js" defer></script>
+
+
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
+    
   <link rel="stylesheet" href="http://34.233.106.94/1/styles.css">
 
   <link rel="stylesheet" href="http://ec2-18-223-135-118.us-east-2.compute.amazonaws.com/1/styles.css">
@@ -19,13 +28,5 @@
   <div id="carousel" style="height: 1000px"></div>
   <div id="review" style="clear: both; bottom : 10px"></div>
 </body>
-
-  <script src="http://34.233.106.94/1/bundle.js"></script>
-
-  <script src="http://ec2-18-223-214-235.us-east-2.compute.amazonaws.com/1/bundle.js"></script>
-
-  <script src="http://ec2-18-223-135-118.us-east-2.compute.amazonaws.com/bundle.js"></script>
-
-
 
 </html>


### PR DESCRIPTION
Hey, I've got 2 versions of the proxy. One pretty standard, the other with the script tags up top with the defer tag on them. The results of the speed tests are in that order. Seems like it's better but I'd love some review.

<img width="726" alt="proxy" src="https://user-images.githubusercontent.com/32114059/51432626-a7150700-1c08-11e9-9c00-4bbfd78a7134.png">

<img width="731" alt="proxy deferscripts" src="https://user-images.githubusercontent.com/32114059/51432630-b005d880-1c08-11e9-8cfe-9abd9e0fd905.png">
